### PR TITLE
Django 4.0 compatibility: move ugettext to gettext

### DIFF
--- a/url_or_relative_url_field/fields.py
+++ b/url_or_relative_url_field/fields.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .forms import URLOrRelativeURLFormField
 from .validators import url_or_relative_url_validator


### PR DESCRIPTION
ugettext was removed in django 4.0 and should be replaced by gettet